### PR TITLE
add additional fields to is_active response

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -73,7 +73,7 @@
   1},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"0068af362ca4ab99b2511a86217a0f874191a771"}},
+       {ref,"1c89c47647aee253a2d4ee178d4fb65e3349515f"}},
   1},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"inert">>,{pkg,<<"inert">>,<<"1.0.2">>},3},

--- a/test/grpc_state_channels_service_SUITE.erl
+++ b/test/grpc_state_channels_service_SUITE.erl
@@ -299,11 +299,12 @@ is_active_sc_test(Config) ->
     #{<<":status">> := HttpStatus1} = Headers1,
     ?assertEqual(HttpStatus1, <<"200">>),
     ?assertEqual(
-        ResponseMsg1#{sc_id := ActiveSCID, sc_owner := SCOwner, active := true},
+        ResponseMsg1#{sc_id := ActiveSCID, sc_owner := SCOwner, active := true, sc_expiry_at_block := 12, sc_original_dc_amount := 20},
         ResponseMsg1
     ),
 
     %% use the grpc APIs to confirm a non existent state channel is not active
+    %% expiry at block and original dc amount values for an inactive SC will default to zero
     {ok, #{
         headers := Headers2,
         result := #{
@@ -324,7 +325,7 @@ is_active_sc_test(Config) ->
     #{<<":status">> := HttpStatus2} = Headers2,
     ?assertEqual(HttpStatus2, <<"200">>),
     ?assertEqual(
-        ResponseMsg2#{sc_id := <<"bad_id">>, sc_owner := SCOwner, active := false},
+        ResponseMsg2#{sc_id := <<"bad_id">>, sc_owner := SCOwner, active := false, sc_expiry_at_block := 0, sc_original_dc_amount := 0},
         ResponseMsg2
     ),
     ok.


### PR DESCRIPTION
Adds fields expiry_at_block and original_dc_amount

Linked PRs:
https://github.com/helium/proto/pull/92