### PR TITLE
Send dispute msg over follow stream

### DIFF
--- a/test/grpc_state_channels_service_SUITE.erl
+++ b/test/grpc_state_channels_service_SUITE.erl
@@ -299,7 +299,13 @@ is_active_sc_test(Config) ->
     #{<<":status">> := HttpStatus1} = Headers1,
     ?assertEqual(HttpStatus1, <<"200">>),
     ?assertEqual(
-        ResponseMsg1#{sc_id := ActiveSCID, sc_owner := SCOwner, active := true, sc_expiry_at_block := 12, sc_original_dc_amount := 20},
+        ResponseMsg1#{
+            sc_id := ActiveSCID,
+            sc_owner := SCOwner,
+            active := true,
+            sc_expiry_at_block := 12,
+            sc_original_dc_amount := 20
+        },
         ResponseMsg1
     ),
 
@@ -325,7 +331,13 @@ is_active_sc_test(Config) ->
     #{<<":status">> := HttpStatus2} = Headers2,
     ?assertEqual(HttpStatus2, <<"200">>),
     ?assertEqual(
-        ResponseMsg2#{sc_id := <<"bad_id">>, sc_owner := SCOwner, active := false, sc_expiry_at_block := 0, sc_original_dc_amount := 0},
+        ResponseMsg2#{
+            sc_id := <<"bad_id">>,
+            sc_owner := SCOwner,
+            active := false,
+            sc_expiry_at_block := 0,
+            sc_original_dc_amount := 0
+        },
         ResponseMsg2
     ),
     ok.


### PR DESCRIPTION
This adds support for a client to receive a dispute state follow msg when a SC enters a disputed state