### PR TITLE
start_link should return {ok, Pid} when started

### DIFF
--- a/src/sibyl_mgr.erl
+++ b/src/sibyl_mgr.erl
@@ -69,7 +69,7 @@ start_link(Args) ->
             %% we likely are the `heir', so we'll get it back if this process dies
             case proplists:get_value(ets, Args) of
                 undefined ->
-                    ok;
+                    {ok, Pid};
                 Tab ->
                     true = ets:give_away(Tab, Pid, undefined),
                     {ok, Pid}


### PR DESCRIPTION
make sibyl_mgr:start_link returns `{ok, Pid}` instead of `ok` if the passed args do not include an ets table