### PR TITLE
guard cache build

### DIFF
--- a/src/sibyl_mgr.erl
+++ b/src/sibyl_mgr.erl
@@ -326,37 +326,41 @@ check_for_asserts(Block) ->
 %% updated periodically, based on VALIDATOR_CACHE_REFRESH setting
 -spec update_validator_cache(Ledger :: blockchain_ledger_v1:ledger()) -> ok.
 update_validator_cache(Ledger) ->
-    {ok, HBInterval} = blockchain:config(?validator_liveness_interval, Ledger),
-    {ok, HBGrace} = blockchain:config(?validator_liveness_grace_period, Ledger),
-    {ok, CurHeight} = blockchain_ledger_v1:current_height(Ledger),
-    Vals =
-        blockchain_ledger_v1:cf_fold(
-            validators,
-            fun({Addr, BinVal}, Acc) ->
-                Validator = blockchain_ledger_validator_v1:deserialize(BinVal),
-                case
-                    (blockchain_ledger_validator_v1:last_heartbeat(Validator) +
-                        HBInterval + HBGrace) >=
-                        CurHeight
-                of
-                    true ->
-                        case get_validator_routing(Addr) of
-                            {ok, URI} ->
+    case blockchain_ledger_v1:config(?validator_liveness_interval, Ledger) of
+        {ok, HBInterval} ->
+            {ok, HBGrace} = blockchain:config(?validator_liveness_grace_period, Ledger),
+            {ok, CurHeight} = blockchain_ledger_v1:current_height(Ledger),
+            Vals =
+                blockchain_ledger_v1:cf_fold(
+                  validators,
+                  fun({Addr, BinVal}, Acc) ->
+                          Validator = blockchain_ledger_validator_v1:deserialize(BinVal),
+                          case
+                              (blockchain_ledger_validator_v1:last_heartbeat(Validator) +
+                                   HBInterval + HBGrace) >=
+                              CurHeight
+                          of
+                              true ->
+                                  case get_validator_routing(Addr) of
+                                      {ok, URI} ->
                                 [{Addr, URI} | Acc];
-                            {error, _} ->
-                                Acc
-                        end;
-                    false ->
-                        Acc
-                end
-            end,
-            [],
-            Ledger
-        ),
-    _ = ets:insert(?TID, {?VALIDATORS, Vals}),
-    %% keep a count of the number of vals in our cache
-    _ = ets:insert(?TID, {?VALIDATOR_COUNT, length(Vals)}),
-    ok.
+                                      {error, _} ->
+                                          Acc
+                                  end;
+                              false ->
+                                  Acc
+                          end
+                  end,
+                  [],
+                  Ledger
+                 ),
+            _ = ets:insert(?TID, {?VALIDATORS, Vals}),
+            %% keep a count of the number of vals in our cache
+            _ = ets:insert(?TID, {?VALIDATOR_COUNT, length(Vals)}),
+            ok;
+        %% liveness not set, vals not enabled, skip for now
+        _ -> ok
+    end.
 
 %% get a public route to the specified validator
 -spec get_validator_routing(libp2p_crypto:pubkey_bin()) -> {error, any()} | {ok, binary()}.


### PR DESCRIPTION
otherwise we can't load the mainnet genesis block, which predates validators.