### PR TITLE
Improve logging and remove unused function

### DIFF
--- a/src/grpc/helium_stream_poc_impl.erl
+++ b/src/grpc/helium_stream_poc_impl.erl
@@ -2,6 +2,7 @@
 
 -include("../../include/sibyl.hrl").
 -include("../grpc/autogen/server/gateway_pb.hrl").
+-include_lib("blockchain/include/blockchain_utils.hrl").
 
 -type handler_state() :: #{
     mod => atom(),
@@ -115,7 +116,7 @@ pocs(
             %% streamed msgs will be received & published by the sibyl_poc_mgr
             %% streamed POC msgs will be potential challenge notifications
             Topic = sibyl_utils:make_poc_topic(Addr),
-            lager:info("gw ~p is subscribing to poc events", [Addr]),
+            lager:info("gw ~p is subscribing to poc events", [?TO_ANIMAL_NAME(Addr)]),
             ok = sibyl_bus:sub(Topic, self()),
             HandlerState = grpcbox_stream:stream_handler_state(StreamState),
             NewStreamState = grpcbox_stream:stream_handler_state(

--- a/src/grpc/helium_unary_poc_impl.erl
+++ b/src/grpc/helium_unary_poc_impl.erl
@@ -2,6 +2,7 @@
 
 -include("../../include/sibyl.hrl").
 -include("../grpc/autogen/server/gateway_pb.hrl").
+-include_lib("blockchain/include/blockchain_utils.hrl").
 
 -export([
     check_challenge_target/2,
@@ -76,7 +77,7 @@ check_challenge_target(
             %% are we the target  ?
             lager:info(
                 "checking if GW ~p is target for poc key ~p",
-                [ChallengeePubKeyBin, POCKey]
+                [?TO_ANIMAL_NAME(ChallengeePubKeyBin), POCKey]
             ),
             {ok, POCMgr} = application:get_env(sibyl, poc_mgr_mod),
             Response0 =

--- a/src/grpc/helium_unary_state_channels_impl.erl
+++ b/src/grpc/helium_unary_state_channels_impl.erl
@@ -135,18 +135,6 @@ close_sc(_Chain, Ctx, #gateway_sc_close_req_v1_pb{close_txn = CloseTxn} = _Messa
 %% Internal functions
 %% ------------------------------------------------------------------
 
--spec check_is_active_sc(
-    SCID :: binary(),
-    SCOwner :: libp2p_crypto:pubkey_bin(),
-    Chain :: blockchain:blockchain()
-) -> true | false.
-check_is_active_sc(SCID, SCOwner, Chain) ->
-    Ledger = blockchain:ledger(Chain),
-    case get_ledger_state_channel(SCID, SCOwner, Ledger) of
-        {ok, _Mod, _SC} -> true;
-        _ -> false
-    end.
-
 -spec check_is_overpaid_sc(
     SCID :: binary(),
     SCOwner :: libp2p_crypto:pubkey_bin(),


### PR DESCRIPTION
This just fixes a couple log messages where the raw pubkey of the gateway is posted, this switches it to use animal-name (we could use B58 instead as well, if that's more appropriate, I chose animal name for readability mostly).

Logs from validator:

```
2022-05-12 22:49:29.144 [info] <0.10604.1>@helium_stream_poc_impl:pocs:{118,13} gw <<0,118,203,136,93,33,121,12,53,99,116,232,2
22,134,19,48,132,27,128,169,235,52,114,55,100,43,85,160,48,134,47,186,191>> is subscribing to poc events
2022-05-12 22:49:32.189 [info] <0.10646.1>@helium_stream_poc_impl:pocs:{118,13} gw <<0,228,179,156,220,210,88,107,32,18,121,222
,218,15,246,211,151,50,115,10,226,59,194,18,191,170,96,26,62,1,23,252,165>> is subscribing to poc events
2022-05-12 22:49:32.807 [info] <0.10669.1>@helium_stream_poc_impl:pocs:{118,13} gw <<0,172,254,132,111,159,53,149,231,9,13,222,
127,199,115,171,170,77,32,74,151,244,170,124,114,217,38,86,255,17,209,24,73>> is subscribing to poc events
```

Secondly, it removes an unused function `check_is_active_sc`.