### PR TITLE
check for GWs going inactive, when connected to a stream. Reactivate if true

### DIFF
--- a/include/sibyl.hrl
+++ b/include/sibyl.hrl
@@ -7,6 +7,7 @@
 -define(EVENT_POC_NOTIFICATION, <<"poc_notification">>).
 -define(EVENT_CONFIG_UPDATE_NOTIFICATION, <<"config_update_notification">>).
 -define(EVENT_ASSERTED_GW_NOTIFICATION, <<"asserted_gw_notification">>).
+-define(EVENT_ACTIVITY_CHECK_NOTIFICATION, <<"activity_check_notification">>).
 
 -define(ALL_EVENTS, [
     ?EVENT_ROUTING_UPDATE,
@@ -16,4 +17,5 @@
     ?EVENT_POC_NOTIFICATION,
     ?EVENT_CONFIG_UPDATE_NOTIFICATION,
     ?EVENT_ASSERTED_GW_NOTIFICATION
+    ?EVENT_ACTIVITY_CHECK_NOTIFICATION
 ]).

--- a/test/grpc_region_params_SUITE.erl
+++ b/test/grpc_region_params_SUITE.erl
@@ -231,10 +231,12 @@ streaming_region_params_test(Config) ->
         block_age := _ResponseBlockAge1,
         signature := _ResponseSig1
     } = Result1,
-    #{  region := ReturnedRegion,
+    #{
+        region := ReturnedRegion,
         params := _ReturnedParams,
         address := Gateway,
-        gain := Gain} = ResponseMsg1,
+        gain := Gain
+    } = ResponseMsg1,
     ?assertEqual(ReturnedRegion, 'US915'),
     ?assertEqual(Gain, 50),
 
@@ -242,7 +244,9 @@ streaming_region_params_test(Config) ->
     AssertLocation2RequestTx = blockchain_txn_assert_location_v2:new(
         Gateway, Owner, Payer, ?TEST_LOCATION2, 2
     ),
-    AssertLocation2RequestTx1 = blockchain_txn_assert_location_v2:gain(AssertLocation2RequestTx, 80),
+    AssertLocation2RequestTx1 = blockchain_txn_assert_location_v2:gain(
+        AssertLocation2RequestTx, 80
+    ),
     SignedAssertLocation2Tx1 = blockchain_txn_assert_location_v2:sign(
         AssertLocation2RequestTx1, OwnerSigFun
     ),
@@ -271,10 +275,12 @@ streaming_region_params_test(Config) ->
         block_age := _ResponseBlockAge2,
         signature := _ResponseSig2
     } = Result2,
-    #{  region := ReturnedRegion2,
+    #{
+        region := ReturnedRegion2,
         params := _ReturnedParams2,
         address := Gateway,
-        gain := Gain2} = ResponseMsg2,
+        gain := Gain2
+    } = ResponseMsg2,
     ?assertEqual(ReturnedRegion2, 'US915'),
     ?assertEqual(Gain2, 80),
     ok.


### PR DESCRIPTION
Adds support to reactive a GW which has gone inactive whilst connected to a stream.  Prior to this change reactivation check would only occur during the initial connect to a stream, now if that connection stays up for a long time we will run periodic activity checks and keep the GW within the active window.

This is to address community reported issues where GWs which are in loosely populated hex are getting excluded from POC due to no active POC activity ( ie no beaconing or witness reports )