### PR TITLE
various optimisations and remove dup event handler sub

### DIFF
--- a/src/grpc/helium_stream_sc_follow_impl.erl
+++ b/src/grpc/helium_stream_sc_follow_impl.erl
@@ -143,8 +143,6 @@ follow_sc(
     SCTopic = sibyl_utils:make_sc_topic(LedgerSCID),
     lager:debug("subscribing to SC events for key ~p and topic ~p", [LedgerSCID, SCTopic]),
     ok = sibyl_bus:sub(SCTopic, self()),
-    %% subscribe to block events so we can get blocktime
-    ok = blockchain_event:add_handler(self()),
     %% add this SC to our follow list
     #{sc_follows := SCFollows} =
         HandlerState = grpcbox_stream:stream_handler_state(
@@ -550,6 +548,8 @@ get_sc_grace(Ledger) ->
 maybe_initialize_state(#{streaming_initialized := true} = HandlerState) ->
     HandlerState;
 maybe_initialize_state(_HandlerState) ->
+    %% subscribe to block events so we can get blocktime
+    ok = blockchain_event:add_handler(self()),
     #{
         mod => ?MODULE,
         sc_follows => #{},


### PR DESCRIPTION
Provides optimisations of the state channel follower RPC.

- Previously  each connected stream would deserialise the SC update received from the ledger hook.  Now this deserialisation is performed once irrespective of how many connected streams.

- Removes duplicate subscription to blockchain events from the stream handler, previously there would have been one subscription per SC follow, now we only do it once per stream

- Derives the current height directly from the blockchain event ledger, rather than deriving the height from a looked up block



