### PR TITLE
default to port 8080 for non host val

### DIFF
--- a/src/grpc/helium_stream_sc_follow_impl.erl
+++ b/src/grpc/helium_stream_sc_follow_impl.erl
@@ -311,7 +311,7 @@ handle_event(
 %% TODO - verify the exact scenarios/triggers for the closing and closable state
 %%        what is below is a best guess for now
 process_sc_block_events(BlockTime, SCGrace, StreamState) ->
-    lager:debug("checking SC for height: ~p",[BlockTime]),
+    lager:debug("checking SC for height: ~p", [BlockTime]),
     %% for each SC we are following, check if we are now in a closable or closing state
     %% ( we will derive close and dispute states from the ledger update events )
     #{sc_follows := SCFollows} = grpcbox_stream:stream_handler_state(
@@ -436,14 +436,17 @@ process_sc_block_events(
     _SCGrace,
     StreamState
 ) ->
-    lager:debug("process_sc_block_events: nothing to do for SC ~p
-                    at blocktime ~p, scExpire ~p, scLastState ~p, scLastBlockTime", [
-        _SCID,
-        _BlockTime,
-        _SCExpireAtHeight,
-        _SCLastState,
-        _SCLastBlockTime
-    ]),
+    lager:debug(
+        "process_sc_block_events: nothing to do for SC ~p\n"
+        "                    at blocktime ~p, scExpire ~p, scLastState ~p, scLastBlockTime",
+        [
+            _SCID,
+            _BlockTime,
+            _SCExpireAtHeight,
+            _SCLastState,
+            _SCLastBlockTime
+        ]
+    ),
     StreamState.
 
 -spec maybe_send_follow_msg(

--- a/src/sibyl_utils.erl
+++ b/src/sibyl_utils.erl
@@ -277,8 +277,16 @@ grpc_port(PubKeyBin) ->
     Aliases = application:get_env(sibyl, node_grpc_port_aliases, []),
     case lists:keyfind(MAddr, 1, Aliases) of
         false ->
-            Port = application:get_env(sibyl, grpc_port, 8080),
-            {Port, false};
+            %% if we are getting port for the host val
+            %% then check the config for any defined port
+            %% otherwise default to port 8080
+            case blockchain_swarm:pubkey_bin() == PubKeyBin of
+                true ->
+                    Port = application:get_env(sibyl, grpc_port, 8080),
+                    {Port, false};
+                false ->
+                    {8080, false}
+            end;
         {MAddr, {Port, SSL}} ->
             {Port, SSL}
     end.


### PR DESCRIPTION
This fixes an issue whereby routing data for routers was being returned with invalid grpc port numbers.

The problem is 2 fold:

1.  Routers are not gossiping a grpc port

2.  The sibyl code to derive a grpc port for a remote peer, and where no gossiped data is available for that peer, would default the port to that defined as the grpc port of the host validator.  As such when a client requests routing data from a durable validator which has overrode the default grpc port of 8080, the response would be incorrect as the grpc port returned for any non gossiped router would be that of the host validator.

This PR addresses point 2 above and does so by defaulting the grpc port to 8080 for any non self pubkeybin.  Obviously if a router itself is not using port 8080 for grpc this will still be correct, but defaulting to 8080 is a better assumption that using that of the host validator.
