### PR TITLE
refresh a peer if not found

### DIFF
--- a/src/sibyl_utils.erl
+++ b/src/sibyl_utils.erl
@@ -252,6 +252,8 @@ check_for_public_uri(PubKeyBin) ->
                     {ok, Addr}
             end;
         {error, not_found} ->
+            %% refresh the peer
+            _ = libp2p_peerbook:refresh(Peerbook, PubKeyBin),
             {error, peer_not_found}
     end.
 


### PR DESCRIPTION
As part of deriving the route for a given validator, force a refresh of the peer should it not be found in the peerbook.

Maybe we should do this in the peerbook itself as part of libp2p_peerbook:get/2, but that obviously touches all apps and so took this route of triggering from sibyl instead