### PR TITLE
Add get_members to return list of subscribers

### DIFF
--- a/src/sibyl_bus.erl
+++ b/src/sibyl_bus.erl
@@ -7,7 +7,8 @@
     start/0,
     sub/2,
     pub/2,
-    leave/2
+    leave/2,
+    get_members/1
 ]).
 
 %% if release not defined default to 20, should be defined from otp21 and up
@@ -31,6 +32,9 @@ pub(Topic, Message) ->
     Members = pg:get_local_members(Topic),
     send_to_members(Members, Message).
 
+get_members(Topic) ->
+    pg:get_members(Topic).
+
 -else.
 
 start() ->
@@ -52,6 +56,9 @@ pub(Topic, Message) ->
         Members ->
             send_to_members(Members, Message)
     end.
+
+get_members(Topic) ->
+    pg2:get_members(Topic).
 
 -endif.
 


### PR DESCRIPTION
Adds a function to the sibyl_bus API for getting the subscribers of a particular topic : get_members/1. This is useful, for example, in checking whether and how many hotspots are subscribed to a validator as in https://github.com/helium/miner/pull/1835.